### PR TITLE
Fix non-closed curly brace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5710,7 +5710,8 @@
           }
         },
         "number-is-nan": {
-          "version": "1.0.1",
+          "version": "1.0.1"
+        },
         "object-assign": {
           "version": "4.1.1",
           "optional": true


### PR DESCRIPTION
Fix the non-closed curly brace which throws error when `npm install` is called.